### PR TITLE
C Gloss link fix

### DIFF
--- a/glossary/C.rst
+++ b/glossary/C.rst
@@ -29,7 +29,7 @@ Casper uses the `Highway <https://docs.casperlabs.io/en/latest/theory/highway.ht
 
 Contract runtime
 ^^^^^^^^^^^^^^^^
-Enables developers to use a seamless workflow for authoring and testing their `smart contracts <S.html#smart-contracts>`_. This environment can also be used for continuous integration, enabling Rust smart contracts to be managed using development best practices.
+Enables developers to use a seamless workflow for authoring and testing their `smart contracts <#smart-contracts>`_. This environment can also be used for continuous integration, enabling Rust smart contracts to be managed using development best practices.
 
 Crate
 ^^^^^


### PR DESCRIPTION
The link to smart contract runtime was not taking the user the exact word spot